### PR TITLE
Use `explicit_bzero` when `HAVE_EXPLICIT_BZERO` is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Alternatively, you can build `ipcrypt2` as a static library. This is useful when
 - Manage dependencies more cleanly in larger codebases
 - Integrate with build systems that prefer library dependencies
 
+To use `explicit_bzero` to zero-out secrets on de-initialization, define `HAVE_EXPLICIT_BZERO` in your build system.
+
 ## Building as a Static Library with Make
 
 Set the appropriate `CFLAGS` if necessary and type:

--- a/src/ipcrypt2.c
+++ b/src/ipcrypt2.c
@@ -862,7 +862,9 @@ ipcrypt_init(IPCrypt *ipcrypt, const uint8_t key[IPCRYPT_KEYBYTES])
 void
 ipcrypt_deinit(IPCrypt *ipcrypt)
 {
-#ifdef _MSC_VER
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(ipcrypt, sizeof *ipcrypt);
+#elif defined (_MSC_VER)
     SecureZeroMemory(ipcrypt, sizeof *ipcrypt);
 #elif defined(__STDC_LIB_EXT1__)
     memset_s(ipcrypt, sizeof *ipcrypt, 0, sizeof *ipcrypt);
@@ -897,7 +899,9 @@ ipcrypt_pfx_init(IPCryptPFX *ipcrypt, const uint8_t key[IPCRYPT_PFX_KEYBYTES])
 void
 ipcrypt_pfx_deinit(IPCryptPFX *ipcrypt)
 {
-#ifdef _MSC_VER
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(ipcrypt, sizeof *ipcrypt);
+#elif defined (_MSC_VER)
     SecureZeroMemory(ipcrypt, sizeof *ipcrypt);
 #elif defined(__STDC_LIB_EXT1__)
     memset_s(ipcrypt, sizeof *ipcrypt, 0, sizeof *ipcrypt);
@@ -1202,7 +1206,9 @@ ipcrypt_ndx_init(IPCryptNDX *ipcrypt, const uint8_t key[IPCRYPT_NDX_KEYBYTES])
 void
 ipcrypt_ndx_deinit(IPCryptNDX *ipcrypt)
 {
-#ifdef _MSC_VER
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(ipcrypt, sizeof *ipcrypt);
+#elif defined (_MSC_VER)
     SecureZeroMemory(ipcrypt, sizeof *ipcrypt);
 #elif defined(__STDC_LIB_EXT1__)
     memset_s(ipcrypt, sizeof *ipcrypt, 0, sizeof *ipcrypt);


### PR DESCRIPTION
Some folks get anxious if `explicit_bzero` is not used for cleaning up secrets (see e.g. https://github.com/PowerDNS/pdns/pull/16123#pullrequestreview-3224073616). This PR allows one to define `HAVE_EXPLICIT_BZERO` and use `explicit_bzero` in all `*_deinit` functions.
