### PR TITLE
Add missing checks for `ipcrypt_str_to_ip16`

### DIFF
--- a/src/ipcrypt2.c
+++ b/src/ipcrypt2.c
@@ -1383,7 +1383,9 @@ ipcrypt_nd_encrypt_ip_str(const IPCrypt *ipcrypt, char encrypted_ip_str[IPCRYPT_
 
     COMPILER_ASSERT(IPCRYPT_NDIP_STR_BYTES == IPCRYPT_NDIP_BYTES * 2 + 1);
     // Convert to 16-byte IP.
-    ipcrypt_str_to_ip16(ip16, ip_str);
+    if (ipcrypt_str_to_ip16(ip16, ip_str) != 0) {
+        return 0;
+    }
     // Perform non-deterministic encryption.
     ipcrypt_nd_encrypt_ip16(ipcrypt, ndip, ip16, random);
     // Convert the 24-byte ndip to a hex string.
@@ -1468,7 +1470,9 @@ ipcrypt_ndx_encrypt_ip_str(const IPCryptNDX *ipcrypt,
 
     COMPILER_ASSERT(IPCRYPT_NDX_NDIP_STR_BYTES == IPCRYPT_NDX_NDIP_BYTES * 2 + 1);
     // Convert to 16-byte IP.
-    ipcrypt_str_to_ip16(ip16, ip_str);
+    if (ipcrypt_str_to_ip16(ip16, ip_str) != 0) {
+        return 0;
+    }
     // Perform non-deterministic encryption.
     ipcrypt_ndx_encrypt_ip16(ipcrypt, ndip, ip16, random);
     // Convert the 32-byte ndip to a hex string.


### PR DESCRIPTION
I noticed that gcc was complaining about possibly using uninitialized memory:
```
In file included from /usr/include/string.h:548,
                 from ipcrypt2.c:37:
In function 'memcpy',
    inlined from 'ipcrypt_nd_encrypt_ip16' at ipcrypt2.c:1349:5,
    inlined from 'ipcrypt_nd_encrypt_ip_str' at ipcrypt2.c:1388:5:
/usr/include/bits/string_fortified.h:29:10: warning: 'ip16' may be used uninitialized [-Wmaybe-uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
ipcrypt2.c: In function 'ipcrypt_nd_encrypt_ip_str':
ipcrypt2.c:1381:13: note: 'ip16' declared here
 1381 |     uint8_t ip16[16];
      |             ^~~~
```

which seems indeed possible if the IPv6 address could not be parsed.